### PR TITLE
Fix deprecation warning from sklearn.

### DIFF
--- a/Seminar1/Homework 1 (Face Recognition).ipynb
+++ b/Seminar1/Homework 1 (Face Recognition).ipynb
@@ -70,9 +70,9 @@
     "data = scipy.io.loadmat('faces_data.mat')\n",
     "\n",
     "X_train = data['train_faces'].reshape((image_w, image_h, -1)).transpose((2, 1, 0)).reshape((-1, image_h * image_w))\n",
-    "y_train = data['train_labels'] - 1\n",
+    "y_train = (data['train_labels'] - 1).reshape((-1,))\n",
     "X_test = data['test_faces'].reshape((image_w, image_h, -1)).transpose((2, 1, 0)).reshape((-1, image_h * image_w))\n",
-    "y_test = data['test_labels'] - 1\n",
+    "y_test = (data['test_labels'] - 1).reshape((-1,))\n",
     "\n",
     "n_features = X_train.shape[1]\n",
     "n_train = len(y_train)\n",
@@ -121,7 +121,7 @@
    },
    "outputs": [],
    "source": [
-    "titles = [str(y[0]) for y in y_train]\n",
+    "titles = [str(y) for y in y_train]\n",
     "\n",
     "plot_gallery(X_train, titles, image_h, image_w)"
    ]
@@ -192,7 +192,7 @@
    "metadata": {},
    "source": [
     "Now we are going to apply **PCA** to obtain a dictionary of codewords. \n",
-    "**`RamdomizedPCA`** class is what we need."
+    "**`PCA`** class is what we need (use `svd_solver='randomized'` for randomized **PCA**)."
    ]
   },
   {
@@ -203,11 +203,11 @@
    },
    "outputs": [],
    "source": [
-    "from sklearn.decomposition import RandomizedPCA\n",
+    "from sklearn.decomposition import PCA\n",
     "\n",
     "n_components = 64\n",
     "\n",
-    "# Populate 'pca' with a trained instance of RamdomizedPCA."
+    "# Populate 'pca' with a trained instance of PCA with svd_solver='randomized'."
    ]
   },
   {


### PR DESCRIPTION
There were two DeprecationWarning's due to

1. shape of labels `y_train` and `y_test`. It should not be dimension of two.
2. removal of `RandomizedPCA` in sklearn 0.20. One should use `PCA` and set up flag `svd_solver` to `randomized` manually.