### PR TITLE
Fix broken json of jupyter notebook.

### DIFF
--- a/Seminar3/HW3_Modules.ipynb
+++ b/Seminar3/HW3_Modules.ipynb
@@ -699,7 +699,7 @@
     "    def updateOutput(self, input, target): \n",
     "        \n",
     "        # Use this trick to avoid numerical errors\n",
-    "        eps = 1e-15 \n
+    "        eps = 1e-15 \n",
     "        input_clamp = np.clip(input, eps, 1 - eps)\n",
     "        \n",
     "        # Your code goes here. ################################################\n",


### PR DESCRIPTION
Please do not edit `ipynb` manually and clear outputs before saving.